### PR TITLE
base inference lambda convert_time 삭제

### DIFF
--- a/lambda-serving/arm_onnx/lambda_function.py
+++ b/lambda-serving/arm_onnx/lambda_function.py
@@ -67,9 +67,9 @@ def lambda_handler(event, context):
         return {
             'model_name': model_name,
             'model_size': model_size,
-            'hardware': hardware,
+            'hardware': "arm",
             'framework': framework,
-            'optimizer': optimizer,
+            'optimizer': "onnx",
             'lambda_memory': lambda_memory,
             'batchsize': batchsize,
             'user_email': user_email,

--- a/lambda-serving/arm_torch/lambda_function.py
+++ b/lambda-serving/arm_torch/lambda_function.py
@@ -55,7 +55,6 @@ def lambda_handler(event, context):
     lambda_memory = event['lambda_memory']
     batchsize = event['batchsize']
     user_email = event['user_email']
-    convert_time = event['convert_time']
 
     if "base" in optimizer and "arm" in hardware:
         res = base_serving(model_name, model_size, batchsize)
@@ -70,7 +69,6 @@ def lambda_handler(event, context):
             'batchsize': batchsize,
             'user_email': user_email,
             'execute': True,
-            'convert_time': convert_time,
             'inference_time': running_time
         }
     else:

--- a/lambda-serving/arm_torch/lambda_function.py
+++ b/lambda-serving/arm_torch/lambda_function.py
@@ -62,9 +62,9 @@ def lambda_handler(event, context):
         return {
             'model_name': model_name,
             'model_size': model_size,
-            'hardware': hardware,
+            'hardware': "base",
             'framework': framework,
-            'optimizer': optimizer,
+            'optimizer': "arm",
             'lambda_memory': lambda_memory,
             'batchsize': batchsize,
             'user_email': user_email,

--- a/lambda-serving/arm_torch/lambda_function.py
+++ b/lambda-serving/arm_torch/lambda_function.py
@@ -62,9 +62,9 @@ def lambda_handler(event, context):
         return {
             'model_name': model_name,
             'model_size': model_size,
-            'hardware': "base",
+            'hardware': "arm",
             'framework': framework,
-            'optimizer': "arm",
+            'optimizer': "base",
             'lambda_memory': lambda_memory,
             'batchsize': batchsize,
             'user_email': user_email,

--- a/lambda-serving/arm_tvm/lambda_function.py
+++ b/lambda-serving/arm_tvm/lambda_function.py
@@ -70,9 +70,9 @@ def lambda_handler(event, context):
         return {
             'model_name': model_name,
             'model_size': model_size,
-            'hardware': hardware,
+            'hardware': "arm",
             'framework': framework,
-            'optimizer': optimizer,
+            'optimizer': "tvm",
             'lambda_memory': lambda_memory,
             'batchsize': batchsize,
             'user_email': user_email,

--- a/lambda-serving/intel_onnx/lambda_function.py
+++ b/lambda-serving/intel_onnx/lambda_function.py
@@ -67,9 +67,9 @@ def lambda_handler(event, context):
         return {
             'model_name': model_name,
             'model_size': model_size,
-            'hardware': hardware,
+            'hardware': "intel",
             'framework': framework,
-            'optimizer': optimizer,
+            'optimizer': "onnx",
             'lambda_memory': lambda_memory,
             'batchsize': batchsize,
             'user_email': user_email,

--- a/lambda-serving/intel_torch/lambda_function.py
+++ b/lambda-serving/intel_torch/lambda_function.py
@@ -60,9 +60,9 @@ def lambda_handler(event, context):
         return {
             'model_name': model_name,
             'model_size': model_size,
-            'hardware': hardware,
+            'hardware': "intel",
             'framework': framework,
-            'optimizer': optimizer,
+            'optimizer': "base",
             'lambda_memory': lambda_memory,
             'batchsize': batchsize,
             'user_email': user_email,

--- a/lambda-serving/intel_torch/lambda_function.py
+++ b/lambda-serving/intel_torch/lambda_function.py
@@ -53,7 +53,6 @@ def lambda_handler(event, context):
     lambda_memory = event['lambda_memory']
     batchsize = event['batchsize']
     user_email = event['user_email']
-    convert_time = event['convert_time']
 
     if "base" in optimizer and "intel" in hardware:
         res = base_serving(model_name, model_size, batchsize)
@@ -68,7 +67,6 @@ def lambda_handler(event, context):
             'batchsize': batchsize,
             'user_email': user_email,
             'execute': True,
-            'convert_time': convert_time,
             'inference_time': running_time
         }
     else:

--- a/lambda-serving/intel_tvm/lambda_function.py
+++ b/lambda-serving/intel_tvm/lambda_function.py
@@ -70,9 +70,9 @@ def lambda_handler(event, context):
         return {
             'model_name': model_name,
             'model_size': model_size,
-            'hardware': hardware,
+            'hardware': "intel",
             'framework': framework,
-            'optimizer': optimizer,
+            'optimizer': "tvm",
             'lambda_memory': lambda_memory,
             'batchsize': batchsize,
             'user_email': user_email,


### PR DESCRIPTION
base의 경우에는 convert_time이 없기 때문에 불필요한 파라미터 return을 삭제했습니다.