### PR TITLE
context 깂 가져오는 방법 변경

### DIFF
--- a/lambda-serving/arm_onnx/lambda_function.py
+++ b/lambda-serving/arm_onnx/lambda_function.py
@@ -87,8 +87,8 @@ def lambda_handler(event, context):
     batchsize = event['batchsize']
     user_email = event['user_email']
     convert_time = event['convert_time']
-    request_id = context['aws_request_id']
-    log_group_name = context['log_group_name']
+    request_id = context.aws_request_id
+    log_group_name = context.log_group_name
 
     info = {
             'model_name': model_name,

--- a/lambda-serving/arm_torch/lambda_function.py
+++ b/lambda-serving/arm_torch/lambda_function.py
@@ -83,8 +83,8 @@ def lambda_handler(event, context):
     lambda_memory = event['lambda_memory']
     batchsize = event['batchsize']
     user_email = event['user_email']
-    request_id = context['aws_request_id']
-    log_group_name = context['log_group_name']
+    request_id = context.aws_request_id
+    log_group_name = context.log_group_name
 
     info = {
                 'model_name': model_name,

--- a/lambda-serving/arm_tvm/lambda_function.py
+++ b/lambda-serving/arm_tvm/lambda_function.py
@@ -94,8 +94,8 @@ def lambda_handler(event, context):
     batchsize = event['batchsize']
     user_email = event['user_email']
     convert_time = event['convert_time']
-    request_id = context['aws_request_id']
-    log_group_name = context['log_group_name']
+    request_id = context.aws_request_id
+    log_group_name = context.log_group_name
 
     info = {
             'model_name': model_name,

--- a/lambda-serving/intel_onnx/lambda_function.py
+++ b/lambda-serving/intel_onnx/lambda_function.py
@@ -88,8 +88,8 @@ def lambda_handler(event, context):
     batchsize = event['batchsize']
     user_email = event['user_email']
     convert_time = event['convert_time']
-    request_id = context['aws_request_id']
-    log_group_name = context['log_group_name']
+    request_id = context.aws_request_id
+    log_group_name = context.log_group_name
 
     info = {
             'model_name': model_name,

--- a/lambda-serving/intel_torch/lambda_function.py
+++ b/lambda-serving/intel_torch/lambda_function.py
@@ -82,8 +82,8 @@ def lambda_handler(event, context):
     lambda_memory = event['lambda_memory']
     batchsize = event['batchsize']
     user_email = event['user_email']
-    request_id = context['aws_request_id']
-    log_group_name = context['log_group_name']
+    request_id = context.aws_request_id
+    log_group_name = context.log_group_name
 
     info = {
             'model_name': model_name,

--- a/lambda-serving/intel_tvm/lambda_function.py
+++ b/lambda-serving/intel_tvm/lambda_function.py
@@ -91,8 +91,8 @@ def lambda_handler(event, context):
     batchsize = event['batchsize']
     user_email = event['user_email']
     convert_time = event['convert_time']
-    request_id = context['aws_request_id']
-    log_group_name = context['log_group_name']
+    request_id = context.aws_request_id
+    log_group_name = context.log_group_name
 
     info = {
             'model_name': model_name,


### PR DESCRIPTION
기존 방식으로 값을 가져왔을 때 에러가 발생하여 '.'을 활용해서 가져와야 정상 동작함을 확인했습니다. 두가지 방식이 차이가 없다고 생각했는데 해당 에러가 발생하여 수정했습니다.
'LambdaContext' object is not subscriptable"